### PR TITLE
Updates docs links to ReadTheDocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Updated documentation links in README and conda recipe to ReadTheDocs
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ pip install .
 
 ## Documentation
 
-Documentation can be found at <https://bryanwweber.github.io/thermostate/>. The documentation contains a short [tutorial](https://bryanwweber.github.io/thermostate/Tutorial.html), [examples](https://bryanwweber.github.io/thermostate/examples.html), and [API documentation](https://bryanwweber.github.io/thermostate/thermostate.html) for the package.
+Documentation can be found at <https://thermostate.readthedocs.io/>. The documentation contains a short [tutorial](https://thermostate.readthedocs.io/en/stable/Tutorial.html), [examples](https://thermostate.readthedocs.io/en/stable/examples.html), and [API documentation](https://thermostate.readthedocs.io/en/stable/thermostate.html) for the package.
+
+[![Documentation Status](https://readthedocs.org/projects/thermostate/badge/?version=stable)](https://thermostate.readthedocs.io/en/stable/?badge=stable)
+
 
 ## Citation
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -47,5 +47,5 @@ about:
     This package provides a wrapper around [CoolProp](https://github.com/CoolProp/CoolProp)
     that integrates [Pint](https://pint.readthedocs.io) for easy thermodynamic state management
     in any unit system.
-  doc_url: https://bryanwweber.github.io/thermostate
+  doc_url: https://thermostate.readthedocs.io/
   dev_url: https://github.com/bryanwweber/thermostate


### PR DESCRIPTION
- [x] Added entry into `CHANGELOG.md`

Changes proposed in this pull request:
 - Fixes documentation links in README to point to ReadTheDocs
 - Adds ReadTheDocs documentation badge in README
 - Fixes documentation link in conda package recipe
